### PR TITLE
Change Fixnums to Integers to fix deprecation warnings on Ruby 2.4

### DIFF
--- a/lib/console_table.rb
+++ b/lib/console_table.rb
@@ -31,7 +31,7 @@ module ConsoleTable
     def initialize(column_layout, options={})
       @original_column_layout = []
 
-      if column_layout.is_a? Fixnum
+      if column_layout.is_a? Integer
         column_layout = (1..column_layout).collect{|i| "Column #{i}"}
       end
 
@@ -39,7 +39,7 @@ module ConsoleTable
         column_layout.each_with_index do |layout, i|
           if layout.is_a? String
             @original_column_layout << {:key => "col#{i+1}".to_sym, :title=>layout, :size=>"*"}
-          elsif layout.is_a? Fixnum
+          elsif layout.is_a? Integer
             @original_column_layout << {:key => "col#{i+1}".to_sym, :title=>"Column #{i+1}", :size=>layout}
           elsif layout.is_a? Float
             @original_column_layout << {:key => "col#{i+1}".to_sym, :title=>"Column #{i+1}", :size=>layout}


### PR DESCRIPTION
This stops the ` warning: constant ::Fixnum is deprecated` messages showing when using `console_table` in apps running under 2.4.

I've confirmed the tests are passing on Ruby 2.4, 2.3 and 1.9.3.

Here are the tests all passing on 2.4.3:

```
(11:26:11) ± [tim@tjl2-mbp.local] ~/code/console_table (fixnums-to-integers ✓) 
→ rake test
Run options: --seed 63723

# Running:

/Users/tim/code/console_table/lib/console_table.rb:282: warning: assigned but unused variable - ex
.......................................................

Finished in 0.030775s, 1787.1649 runs/s, 13192.5264 assertions/s.

55 runs, 406 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Users/tim/code/console_table/coverage. 242 / 244 LOC (99.18%) covered.
```

Let me know if you need anything else! Thanks.