### PR TITLE
move away from using terminfo to determine the window columns, use the stdlib IO/Console instead

### DIFF
--- a/console_table.gemspec
+++ b/console_table.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "console_table"
-  spec.version       = "0.3.0"
+  spec.version       = "0.3.1"
   spec.authors       = ["Rod Hilton"]
   spec.email         = ["consoletable@rodhilton.com"]
   spec.summary       = %q{Simplifies printing tables of information to commandline consoles}
@@ -17,10 +17,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'simplecov', '~> 0.9'
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", "~> 2.3.7"
   spec.add_development_dependency 'rake', '~> 0'
   spec.add_development_dependency 'minitest', '~> 5.5'
   spec.add_development_dependency 'colorize', '~> 0.7'
+  spec.add_development_dependency 'pry'
 
-  spec.add_runtime_dependency 'ruby-terminfo', '~> 0.1'
 end

--- a/lib/console_table.rb
+++ b/lib/console_table.rb
@@ -16,7 +16,7 @@ module ConsoleTable
   end
 
   class ConsoleTableClass
-    require 'terminfo'
+    require 'io/console'
 
     # Add strings to the footer array to have them formatted when the table closes
     attr_reader :footer
@@ -278,7 +278,7 @@ module ConsoleTable
 
       total_width = @set_width
       begin
-        total_width = TermInfo.screen_columns
+        total_width = IO.console.winsize[1]
       rescue => ex
         total_width = ENV["COLUMNS"].to_i unless ENV["COLUMNS"].nil?
         total_width = 79 if total_width.nil?


### PR DESCRIPTION
Terminfo isn't yet built for Ruby 3.x, hasn't had a release in quite some time which is proving problematic. We can get the same result from the io/console call to winsize() and remove reliance on an external library.
